### PR TITLE
fixed typo in variable for vod-pipeline example

### DIFF
--- a/examples/vod-pipeline/main.tf
+++ b/examples/vod-pipeline/main.tf
@@ -107,7 +107,7 @@ provider "osc" {
 
 resource "osc_secret" "miniousername" {
   service_ids  = ["minio-minio", "encore", "eyevinn-encore-packager"]
-  secret_name  = "${var.vodpipeline_name}mminiousername"
+  secret_name  = "${var.vodpipeline_name}miniousername"
   secret_value = var.minio_username
 }
 


### PR DESCRIPTION
Fixed a small typo in one of the varibles