### PR TITLE
feat: added auto generated password if database_password is left blank

### DIFF
--- a/examples/penpot/main.tf
+++ b/examples/penpot/main.tf
@@ -40,6 +40,10 @@ variable "database_password" {
   description = "Set the PostgreSQL database password. Leave empty to have it auto-generated"
 }
 
+locals {
+  db_password_final = var.database_password != null && var.database_password != "null" ? var.database_password : random_password.db_password.result
+}
+
 ############################
 # Provider
 ############################
@@ -54,10 +58,6 @@ provider "osc" {
 resource "random_password" "db_password" {
   length  = 16
   special = false
-}
-
-locals {
-  db_password_final = var.database_password != null && var.database_password != "null" ? var.database_password : random_password.db_password.result
 }
 
 ############################


### PR DESCRIPTION
I added the same logic as in intercom to generate a password for database_password. 

I did a quick test in the cursor assistant with the OSC token and it said worked but not sure how to properly test it. 

<img width="979" height="646" alt="Screenshot 2025-12-04 at 13 07 19" src="https://github.com/user-attachments/assets/0a3fbc12-3830-44e4-9d8d-c3e1dbd8e457" />
