### PR TITLE
Add C2PA demo platform solution

### DIFF
--- a/examples/c2pa-demo/README.md
+++ b/examples/c2pa-demo/README.md
@@ -1,0 +1,109 @@
+## Terraform/OpenTofu Example - C2PA Demo Platform
+
+Deploy a C2PA (Coalition for Content Provenance and Authenticity) demo platform for live video streaming. The platform demonstrates two approaches for per-segment content authenticity verification in DASH and HLS streams.
+
+### What you get
+
+- **Landing page** with interactive comparison of both C2PA approaches
+- **emsg player** (Unified Streaming approach) — DASH with `emsg` boxes carrying COSE_Sign1 signatures
+- **uuid player** (EZDRM/Qualabs approach) — DASH + HLS with `uuid` boxes and CBC hash chaining
+- **Hack toggle** — Live MITM attack simulation showing verification detecting tampered segments
+- **Upload & Sign** — Import CMAF content and sign it with either approach
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    C2PA Demo Platform                        │
+│                                                             │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐  │
+│  │   Landing    │───▶│    Signer    │    │    MinIO     │  │
+│  │  (Web Runner)│    │ (Web Runner) │───▶│  (Storage)   │  │
+│  │              │───▶│              │    │              │  │
+│  │  dash.js     │    │  emsg sign   │    │  segments    │  │
+│  │  hls.js      │    │  uuid sign   │    │  manifests   │  │
+│  │  C2PA verify │    │  COSE_Sign1  │    │  keys        │  │
+│  └──────┬───────┘    └──────────────┘    └──────────────┘  │
+│         │                                                   │
+│  ┌──────┴───────┐    ┌──────────────┐                      │
+│  │  App Config  │    │    Valkey    │                      │
+│  │  (Params)    │───▶│   (State)   │                      │
+│  └──────────────┘    └──────────────┘                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Services used
+
+| Service | Purpose |
+|---------|---------|
+| MinIO | S3-compatible storage for video segments and manifests |
+| Valkey | State management for signing jobs and hack toggle |
+| App Config Service | Parameter store for shared configuration |
+| Web Runner (signer) | Background signing worker with emsg and uuid support |
+| Web Runner (landing) | Landing page, players, stream proxy, API |
+
+### Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `osc_pat` | Yes | - | Eyevinn OSC Personal Access Token |
+| `osc_environment` | No | `prod` | OSC Environment (prod/stage/dev) |
+| `name` | No | `c2pademo` | Solution name (lowercase letters and numbers only) |
+| `minio_username` | Yes | - | MinIO root username |
+| `minio_password` | Yes | - | MinIO root password |
+| `minio_bucket` | No | `c2pa` | S3 bucket name |
+| `valkey_password` | No | auto-generated | Password for Valkey instance |
+
+### Prerequisites
+
+- AWS CLI installed (for bucket creation)
+- Terraform >= 1.6.0 or OpenTofu >= 1.6.0
+
+### Quick Start
+
+1. Set your OSC Personal Access Token and MinIO credentials:
+   ```bash
+   export TF_VAR_osc_pat=<your-token>
+   export TF_VAR_minio_username=<username>
+   export TF_VAR_minio_password=<password>
+   ```
+
+2. Initialize and apply:
+   ```bash
+   terraform init
+   terraform apply
+   ```
+
+3. Access the demo platform at the `demo_url` output.
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `demo_url` | Main landing page URL |
+| `emsg_player_url` | Direct link to emsg demo player |
+| `uuid_player_url` | Direct link to uuid demo player |
+| `signer_url` | Signing service URL |
+| `minio_instance_url` | MinIO storage URL |
+
+### C2PA Approaches
+
+**emsg (Unified Streaming)**
+- Event Message boxes with scheme URI `urn:c2pa:verifiable-segment-info`
+- Full-box hashing (sidx + moof + mdat)
+- DASH only
+- Per-segment COSE_Sign1 (ECDSA P-256)
+
+**uuid (EZDRM/Qualabs)**
+- UUID boxes with C2PA JUMBF identifier
+- mdat-only hashing with CBC hash chaining
+- Anchor resets every 10 segments
+- DASH + HLS (CMAF fMP4)
+- Per-segment COSE_Sign1 (ECDSA P-256)
+
+### Source repositories
+
+- [Eyevinn/c2pa-demo-landing](https://github.com/Eyevinn/c2pa-demo-landing) — Landing page, players, API
+- [Eyevinn/c2pa-demo-signer](https://github.com/Eyevinn/c2pa-demo-signer) — Signing worker
+
+See general guidelines [here](../../README.md#quick-guide---general)

--- a/examples/c2pa-demo/create_bucket.sh
+++ b/examples/c2pa-demo/create_bucket.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Create S3 bucket on MinIO instance
+# Usage: create_bucket.sh <minio_url> <bucket_name>
+# Requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars
+
+MINIO_URL=$1
+BUCKET=$2
+MAX_RETRIES=10
+RETRY_DELAY=5
+
+echo "Creating bucket '$BUCKET' on $MINIO_URL..."
+
+for i in $(seq 1 $MAX_RETRIES); do
+  aws s3 mb "s3://$BUCKET" \
+    --endpoint-url "$MINIO_URL" \
+    --region us-east-1 \
+    2>/dev/null && {
+    echo "Bucket '$BUCKET' created successfully."
+    exit 0
+  }
+
+  # Check if bucket already exists
+  aws s3 ls "s3://$BUCKET" \
+    --endpoint-url "$MINIO_URL" \
+    --region us-east-1 \
+    2>/dev/null && {
+    echo "Bucket '$BUCKET' already exists."
+    exit 0
+  }
+
+  echo "Attempt $i/$MAX_RETRIES failed, retrying in ${RETRY_DELAY}s..."
+  sleep $RETRY_DELAY
+done
+
+echo "ERROR: Failed to create bucket after $MAX_RETRIES attempts"
+exit 1

--- a/examples/c2pa-demo/main.tf
+++ b/examples/c2pa-demo/main.tf
@@ -1,0 +1,275 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    osc = {
+      source  = "registry.terraform.io/EyevinnOSC/osc"
+      version = "0.5.0"
+    }
+  }
+}
+
+############################
+# Variables (inputs)
+############################
+
+## --- General ---
+
+variable "osc_pat" {
+  type        = string
+  sensitive   = true
+  description = "Eyevinn OSC Personal Access Token"
+}
+
+variable "osc_environment" {
+  type        = string
+  default     = "prod"
+  description = "OSC Environment (prod/stage/dev)"
+}
+
+variable "name" {
+  type        = string
+  default     = "c2pademo"
+  description = "Solution name. Lower case letters and numbers only"
+}
+
+## --- MinIO ---
+
+variable "minio_username" {
+  type        = string
+  sensitive   = true
+  description = "MinIO root username"
+}
+
+variable "minio_password" {
+  type        = string
+  sensitive   = true
+  description = "MinIO root password"
+}
+
+variable "minio_bucket" {
+  type        = string
+  default     = "c2pa"
+  description = "S3 bucket name for C2PA content"
+}
+
+## --- Valkey ---
+
+variable "valkey_password" {
+  type        = string
+  default     = null
+  sensitive   = true
+  description = "Password for Valkey. Leave empty to auto-generate"
+}
+
+locals {
+  valkey_password_final = var.valkey_password != null && var.valkey_password != "null" ? var.valkey_password : random_password.valkey_password.result
+  valkey_redis_url      = format("redis://default:%s@%s:%d", local.valkey_password_final, osc_valkey_io_valkey.this.external_ip, osc_valkey_io_valkey.this.external_port)
+}
+
+############################
+# Provider
+############################
+provider "osc" {
+  pat         = var.osc_pat
+  environment = var.osc_environment
+}
+
+############################
+# Resource: Random passwords
+############################
+resource "random_password" "valkey_password" {
+  length  = 16
+  special = false
+}
+
+############################
+# Resource: Secrets
+############################
+
+resource "osc_secret" "miniousername" {
+  service_ids  = ["minio-minio"]
+  secret_name  = "${var.name}miniousername"
+  secret_value = var.minio_username
+}
+
+resource "osc_secret" "miniopassword" {
+  service_ids  = ["minio-minio"]
+  secret_name  = "${var.name}miniopassword"
+  secret_value = var.minio_password
+}
+
+resource "osc_secret" "valkeypassword" {
+  service_ids  = ["valkey-io-valkey"]
+  secret_name  = "${var.name}valkeypassword"
+  secret_value = local.valkey_password_final
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "osc_secret" "redis_url" {
+  service_ids  = ["eyevinn-app-config-svc"]
+  secret_name  = "${var.name}redisurl"
+  secret_value = local.valkey_redis_url
+  depends_on   = [osc_valkey_io_valkey.this]
+}
+
+############################
+# Resource: MinIO storage
+############################
+resource "osc_minio_minio" "this" {
+  name          = var.name
+  root_user     = format("{{secrets.%s}}", osc_secret.miniousername.secret_name)
+  root_password = format("{{secrets.%s}}", osc_secret.miniopassword.secret_name)
+}
+
+############################
+# Resource: Create S3 bucket
+############################
+resource "null_resource" "create_bucket" {
+  depends_on = [osc_minio_minio.this]
+
+  provisioner "local-exec" {
+    command     = "${path.module}/create_bucket.sh ${osc_minio_minio.this.instance_url} ${var.minio_bucket}"
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      AWS_ACCESS_KEY_ID     = var.minio_username
+      AWS_SECRET_ACCESS_KEY = var.minio_password
+    }
+  }
+}
+
+############################
+# Resource: Valkey
+############################
+resource "osc_valkey_io_valkey" "this" {
+  name     = var.name
+  password = format("{{secrets.%s}}", osc_secret.valkeypassword.secret_name)
+}
+
+############################
+# Resource: App Config Service (Parameter Store)
+############################
+resource "osc_eyevinn_app_config_svc" "this" {
+  name      = var.name
+  redis_url = format("{{secrets.%s}}", osc_secret.redis_url.secret_name)
+
+  depends_on = [osc_valkey_io_valkey.this, osc_secret.redis_url]
+}
+
+############################
+# Seed parameter store with config values
+############################
+resource "null_resource" "seed_config" {
+  depends_on = [
+    osc_eyevinn_app_config_svc.this,
+    osc_minio_minio.this,
+    osc_valkey_io_valkey.this,
+    null_resource.create_bucket
+  ]
+
+  provisioner "local-exec" {
+    command     = "${path.module}/seed_config.sh"
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      CONFIG_URL       = osc_eyevinn_app_config_svc.this.instance_url
+      MINIO_ENDPOINT   = osc_minio_minio.this.instance_url
+      MINIO_ACCESS_KEY = var.minio_username
+      MINIO_SECRET_KEY = var.minio_password
+      MINIO_BUCKET     = var.minio_bucket
+      VALKEY_URL       = local.valkey_redis_url
+    }
+  }
+}
+
+############################
+# Resource: Web Runner — C2PA Signer
+############################
+resource "osc_eyevinn_web_runner" "signer" {
+  name           = "${var.name}signer"
+  source_url     = "https://github.com/Eyevinn/c2pa-demo-signer"
+  config_service = var.name
+
+  depends_on = [null_resource.seed_config]
+}
+
+############################
+# Seed SIGNER_URL into parameter store (needs signer URL)
+############################
+resource "null_resource" "seed_signer_url" {
+  depends_on = [osc_eyevinn_web_runner.signer]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      sleep 5
+      curl -sf -X PUT "${osc_eyevinn_app_config_svc.this.instance_url}/api/v1/config/SIGNER_URL" \
+        -H "Content-Type: application/json" \
+        -d '{"value": "${osc_eyevinn_web_runner.signer.instance_url}"}'
+    EOT
+    interpreter = ["/bin/bash", "-c"]
+  }
+}
+
+############################
+# Resource: Web Runner — C2PA Landing Page
+############################
+resource "osc_eyevinn_web_runner" "landing" {
+  name           = "${var.name}landing"
+  source_url     = "https://github.com/Eyevinn/c2pa-demo-landing"
+  config_service = var.name
+
+  depends_on = [null_resource.seed_signer_url]
+}
+
+############################
+# Outputs
+############################
+
+## --- Landing Page (main entry point) ---
+output "demo_url" {
+  value       = osc_eyevinn_web_runner.landing.instance_url
+  description = "C2PA Demo Platform URL"
+}
+
+output "emsg_player_url" {
+  value       = "${osc_eyevinn_web_runner.landing.instance_url}/emsg/?demo=true"
+  description = "emsg (Unified Streaming) demo player"
+}
+
+output "uuid_player_url" {
+  value       = "${osc_eyevinn_web_runner.landing.instance_url}/uuid/?demo=true"
+  description = "uuid (EZDRM/Qualabs) demo player"
+}
+
+## --- Signer ---
+output "signer_url" {
+  value = osc_eyevinn_web_runner.signer.instance_url
+}
+
+output "signer_service_id" {
+  value = osc_eyevinn_web_runner.signer.service_id
+}
+
+## --- MinIO ---
+output "minio_instance_url" {
+  value = osc_minio_minio.this.instance_url
+}
+
+output "minio_service_id" {
+  value = osc_minio_minio.this.service_id
+}
+
+## --- Valkey ---
+output "valkey_instance_url" {
+  value = osc_valkey_io_valkey.this.instance_url
+}
+
+output "valkey_service_id" {
+  value = osc_valkey_io_valkey.this.service_id
+}
+
+## --- App Config Service ---
+output "config_service_url" {
+  value = osc_eyevinn_app_config_svc.this.instance_url
+}

--- a/examples/c2pa-demo/seed_config.sh
+++ b/examples/c2pa-demo/seed_config.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Seed parameter store with configuration values
+# Requires: CONFIG_URL, MINIO_ENDPOINT, MINIO_ACCESS_KEY, MINIO_SECRET_KEY, MINIO_BUCKET, VALKEY_URL
+
+set -e
+MAX_RETRIES=10
+RETRY_DELAY=5
+
+echo "Waiting for config service at $CONFIG_URL..."
+
+for i in $(seq 1 $MAX_RETRIES); do
+  STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "$CONFIG_URL/api/v1/config" 2>/dev/null || echo "000")
+  if [ "$STATUS" = "200" ]; then
+    echo "Config service is ready."
+    break
+  fi
+  echo "Attempt $i/$MAX_RETRIES (status=$STATUS), retrying in ${RETRY_DELAY}s..."
+  sleep $RETRY_DELAY
+  if [ "$i" = "$MAX_RETRIES" ]; then
+    echo "ERROR: Config service not ready after $MAX_RETRIES attempts"
+    exit 1
+  fi
+done
+
+echo "Setting configuration values..."
+
+set_config() {
+  local key=$1
+  local value=$2
+  curl -sf -X PUT "$CONFIG_URL/api/v1/config/$key" \
+    -H "Content-Type: application/json" \
+    -d "{\"value\": \"$value\"}" > /dev/null
+  echo "  $key = set"
+}
+
+set_config "MINIO_ENDPOINT" "$MINIO_ENDPOINT"
+set_config "MINIO_ACCESS_KEY" "$MINIO_ACCESS_KEY"
+set_config "MINIO_SECRET_KEY" "$MINIO_SECRET_KEY"
+set_config "MINIO_BUCKET" "$MINIO_BUCKET"
+set_config "VALKEY_URL" "$VALKEY_URL"
+
+echo "Configuration seeded successfully."


### PR DESCRIPTION
## Summary
- Adds a new Terraform solution `c2pa-demo` that deploys a complete C2PA content authenticity demo platform for live video streaming
- Creates MinIO (storage), Valkey (state), App Config Service (parameter store), and two Web Runner apps (signer + landing page)
- Demonstrates both **emsg** (Unified Streaming) and **uuid** (EZDRM/Qualabs) approaches for per-segment C2PA verification in DASH and HLS

## Services deployed (5)
| Service | Purpose |
|---------|---------|
| MinIO | S3-compatible storage for video segments and manifests |
| Valkey | State management for signing jobs and hack toggle |
| App Config Service | Shared parameter store |
| Web Runner (signer) | Background C2PA signing worker |
| Web Runner (landing) | Landing page, dash.js/hls.js players, stream proxy, API |

## Variables (7)
| Variable | Required | Default |
|----------|----------|---------|
| `osc_pat` | Yes | - |
| `name` | No | `c2pademo` |
| `minio_username` | Yes | - |
| `minio_password` | Yes | - |
| `minio_bucket` | No | `c2pa` |
| `valkey_password` | No | auto-generated |
| `osc_environment` | No | `prod` |

## Source repos
- [Eyevinn/c2pa-demo-landing](https://github.com/Eyevinn/c2pa-demo-landing)
- [Eyevinn/c2pa-demo-signer](https://github.com/Eyevinn/c2pa-demo-signer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)