### PR TITLE
fix: replace bash with POSIX sh for deploy-manager compatibility

### DIFF
--- a/examples/open-analytics/main.tf
+++ b/examples/open-analytics/main.tf
@@ -4,7 +4,7 @@ terraform {
     osc = {
       source = "registry.terraform.io/EyevinnOSC/osc"
       #source = "local/eyevinnosc/osc" 
-      version = "0.4.0"
+      version = "0.6.0"
     }
   }
 }
@@ -117,9 +117,9 @@ resource "null_resource" "create_queue" {
       AWS_ACCESS_KEY_ID     = var.smoothmqaccesskey
       AWS_SECRET_ACCESS_KEY = var.smoothmqsecretkey
     }
-    interpreter = ["/bin/bash", "-c"]
+    interpreter = ["/bin/sh", "-c"]
     command     = <<EOT
-      bash ${path.module}/scripts/create_queue.sh \
+      sh ${path.module}/scripts/create_queue.sh \
       ${osc_poundifdef_smoothmq.smooth_mq_instance.instance_url} \
       ${osc_poundifdef_smoothmq.smooth_mq_instance.name}
     EOT
@@ -137,7 +137,7 @@ resource "null_resource" "create_queue" {
 # Read the queue URL from file if it exists, otherwise return empty (for destroy operations)
 # Using external data source instead of local_file to handle missing file gracefully
 data "external" "queue_info" {
-  program = ["bash", "-c", "if [ -f '${path.module}/queue_output.json' ]; then cat '${path.module}/queue_output.json'; else echo '{\"QueueUrl\": \"\"}'; fi"]
+  program = ["sh", "-c", "if [ -f '${path.module}/queue_output.json' ]; then cat '${path.module}/queue_output.json'; else echo '{\"QueueUrl\": \"\"}'; fi"]
 
   depends_on = [null_resource.create_queue]
 }
@@ -155,9 +155,9 @@ resource "null_resource" "wait_for_queue" {
       AWS_ACCESS_KEY_ID     = var.smoothmqaccesskey
       AWS_SECRET_ACCESS_KEY = var.smoothmqsecretkey
     }
-    interpreter = ["/bin/bash", "-c"]
+    interpreter = ["/bin/sh", "-c"]
     command     = <<EOT
-      bash ${path.module}/scripts/wait_for_queue.sh \
+      sh ${path.module}/scripts/wait_for_queue.sh \
         ${local.queue_url} \
         ${osc_poundifdef_smoothmq.smooth_mq_instance.instance_url}
     EOT

--- a/examples/open-analytics/scripts/create_queue.sh
+++ b/examples/open-analytics/scripts/create_queue.sh
@@ -1,7 +1,13 @@
-#!/usr/bin/env bash
+#!/bin/sh
+set -e
 
 INSTANCE_URL="$1"
 QUEUE_NAME="$2"
+
+if [ -z "$INSTANCE_URL" ] || [ -z "$QUEUE_NAME" ]; then
+  echo "Usage: create_queue.sh <instance_url> <queue_name>" >&2
+  exit 1
+fi
 
 i=1
 while [ $i -le 30 ]; do
@@ -14,7 +20,16 @@ while [ $i -le 30 ]; do
     echo "Instance ready, creating queue '${QUEUE_NAME}' …"
     QUEUE_JSON=$(aws --endpoint-url "${INSTANCE_URL}" \
                      --region eu-west-1 \
-                     sqs create-queue --queue-name "${QUEUE_NAME}")
+                     sqs create-queue --queue-name "${QUEUE_NAME}") || {
+      echo "FATAL: aws sqs create-queue failed" >&2
+      exit 1
+    }
+
+    # Validate that the response contains a QueueUrl
+    if ! echo "$QUEUE_JSON" | grep -q '"QueueUrl"'; then
+      echo "FATAL: create-queue response missing QueueUrl: $QUEUE_JSON" >&2
+      exit 1
+    fi
 
     echo "Queue creation output:"
     echo "$QUEUE_JSON"
@@ -30,5 +45,5 @@ while [ $i -le 30 ]; do
   sleep 5
 done
 
-echo "Instance not ready in time" >&2
+echo "FATAL: SmoothMQ instance not ready after 150 seconds" >&2
 exit 1

--- a/examples/open-analytics/scripts/wait_for_queue.sh
+++ b/examples/open-analytics/scripts/wait_for_queue.sh
@@ -1,7 +1,12 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 QUEUE_URL="$1"
 ENDPOINT_URL="$2"
+
+if [ -z "$QUEUE_URL" ] || [ -z "$ENDPOINT_URL" ]; then
+  echo "Usage: wait_for_queue.sh <queue_url> <endpoint_url>" >&2
+  exit 1
+fi
 
 i=1
 while [ $i -le 30 ]; do
@@ -17,5 +22,5 @@ while [ $i -le 30 ]; do
   sleep 5
 done
 
-echo "Queue not ready in time" >&2
+echo "FATAL: Queue not ready after 150 seconds" >&2
 exit 1


### PR DESCRIPTION
## Summary

- Replace `/bin/bash` interpreter with `/bin/sh` in all `local-exec` provisioners
- Update script shebangs from `#!/usr/bin/env bash` to `#!/bin/sh`
- Add error handling for `aws sqs create-queue` (validate QueueUrl in response)
- Add input validation to both shell scripts
- Update OSC provider version from 0.4.0 to 0.6.0

## Root Cause

The deploy-manager runs terraform in an Alpine-based OpenTofu container (`ghcr.io/opentofu/opentofu:latest`) which does **not** have `/bin/bash`. The `apk add aws-cli` installs the AWS CLI but does not pull in bash as a dependency.

When the `null_resource.create_queue` provisioner runs with `interpreter = ["/bin/bash", "-c"]`, it fails with "file not found". This causes `tofu apply` to fail partway through — after some resources are created but before the queue and dependent services are configured.

Combined with a deploy-manager bug (state-save + job self-deletion running on partial failures), this results in the phantom success / 0 instances / JOB_NOT_FOUND pattern reported in Eyevinn/open-analytics-site#42.

## Test plan

- [ ] Deploy the open-analytics solution via `deploy-solution` MCP tool
- [ ] Verify all 5 services are created and running
- [ ] Verify `get-deployment-status` shows Completed/Succeeded
- [ ] Verify `list-service-instances` returns all expected instances


🤖 Generated with [Claude Code](https://claude.com/claude-code)