### PR TITLE
feat: add Mobile Backend Starter solution

### DIFF
--- a/examples/mobile-backend/README.md
+++ b/examples/mobile-backend/README.md
@@ -1,0 +1,83 @@
+## Terraform/OpenTofu Example - Mobile Backend Starter
+
+A production-ready Backend-as-a-Service (BaaS) stack for mobile applications, composed entirely from open source software on Eyevinn OSC. Deploy a full backend in minutes with no vendor lock-in.
+
+### What gets deployed
+
+| Service | Role |
+|---|---|
+| PostgreSQL | Relational database |
+| PostgREST | Auto-generated REST API from your database schema |
+| MinIO | S3-compatible object storage for files and media |
+| OpenAuth Password | Email/password authentication with JWT |
+| Valkey | Redis-compatible cache and session store |
+| Flyimg | On-demand image transforms (resize, crop, format) |
+| CouchDB | User store for the auth service |
+
+All secrets (passwords) are auto-generated unless you provide them explicitly. Service wiring is handled automatically via OSC secrets.
+
+### Prerequisites
+
+- An [Eyevinn OSC](https://app.osaas.io) account (paid plan recommended for SMTP access)
+- Terraform >= 1.6.0 or OpenTofu >= 1.6.0
+- An SMTP URL for email verification (e.g. `smtps://user:password@smtp.example.com:465`)
+  - OSC paid tenants: find SMTP credentials under Team Settings > Email
+
+### Quickstart
+
+```bash
+cd examples/mobile-backend
+
+# Export sensitive variables
+export TF_VAR_osc_pat=<YOUR OSC PERSONAL ACCESS TOKEN>
+export TF_VAR_smtp_url=<YOUR SMTP URL>
+
+# Initialize providers
+terraform init
+
+# Preview what will be created
+terraform plan -var="solution_name=mybackend"
+
+# Deploy
+terraform apply -var="solution_name=mybackend"
+```
+
+After apply completes, Terraform prints all connection URLs and endpoints.
+
+### Variables
+
+| Name | Default | Description |
+|---|---|---|
+| `osc_pat` | required | OSC Personal Access Token |
+| `osc_environment` | `prod` | OSC environment (`prod`, `stage`, `dev`) |
+| `solution_name` | `mybackend` | Name prefix for all services. Lowercase letters and numbers only |
+| `smtp_url` | required | SMTP URL for email verification |
+| `database_password` | auto-generated | PostgreSQL password |
+| `couchdb_password` | auto-generated | CouchDB admin password |
+| `minio_password` | auto-generated | MinIO admin password |
+| `valkey_password` | auto-generated | Valkey password |
+
+### Outputs
+
+| Name | Description |
+|---|---|
+| `postgresql_url` | PostgreSQL connection URL |
+| `rest_api_url` | PostgREST REST API URL |
+| `minio_console_url` | MinIO web console URL |
+| `minio_endpoint` | MinIO S3-compatible endpoint (`host:port`) |
+| `minio_access_key` | MinIO access key (S3 access key ID) |
+| `auth_url` | OpenAuth Password service URL |
+| `valkey_url` | Valkey connection URL (`redis://host:port`) |
+| `flyimg_url` | Flyimg image transform service URL |
+
+### Zero lock-in
+
+Every service in this stack is open source software running on standard protocols. Your data stays in PostgreSQL and MinIO — both exportable at any time. Switch providers or self-host by pointing your connection strings elsewhere. No proprietary APIs, no vendor-specific SDKs required.
+
+### Tear down
+
+```bash
+terraform destroy
+```
+
+See general guidelines [here](../../README.md#quick-guide---general)

--- a/examples/mobile-backend/main.tf
+++ b/examples/mobile-backend/main.tf
@@ -1,0 +1,264 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    osc = {
+      source  = "registry.terraform.io/EyevinnOSC/osc"
+      version = "0.6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+  }
+}
+
+############################
+# Variables
+############################
+
+variable "osc_pat" {
+  type        = string
+  sensitive   = true
+  description = "Eyevinn OSC Personal Access Token"
+}
+
+variable "osc_environment" {
+  type        = string
+  default     = "prod"
+  description = "OSC Environment"
+}
+
+variable "solution_name" {
+  type        = string
+  default     = "mybackend"
+  description = "Name prefix for all services. Lowercase letters and numbers only"
+}
+
+variable "smtp_url" {
+  type        = string
+  description = "SMTP URL for email verification. OSC paid tenants: use OSC mailbox SMTP credentials from Team Settings > Email"
+}
+
+variable "database_password" {
+  type        = string
+  default     = null
+  sensitive   = true
+  description = "PostgreSQL password. Leave empty to auto-generate"
+}
+
+variable "couchdb_password" {
+  type        = string
+  default     = null
+  sensitive   = true
+  description = "CouchDB admin password. Leave empty to auto-generate"
+}
+
+variable "minio_password" {
+  type        = string
+  default     = null
+  sensitive   = true
+  description = "MinIO admin password. Leave empty to auto-generate"
+}
+
+variable "valkey_password" {
+  type        = string
+  default     = null
+  sensitive   = true
+  description = "Valkey password. Leave empty to auto-generate"
+}
+
+############################
+# Provider
+############################
+
+provider "osc" {
+  pat         = var.osc_pat
+  environment = var.osc_environment
+}
+
+############################
+# Random Passwords
+############################
+
+resource "random_password" "db_password" {
+  length  = 16
+  special = false
+}
+
+resource "random_password" "couchdb_password" {
+  length  = 16
+  special = false
+}
+
+resource "random_password" "minio_password" {
+  length      = 16
+  special     = false
+  min_upper   = 1
+  min_lower   = 1
+  min_numeric = 1
+}
+
+resource "random_password" "valkey_password" {
+  length  = 16
+  special = false
+}
+
+locals {
+  db_password_final      = var.database_password != null && var.database_password != "null" ? var.database_password : random_password.db_password.result
+  couchdb_password_final = var.couchdb_password != null && var.couchdb_password != "null" ? var.couchdb_password : random_password.couchdb_password.result
+  minio_password_final   = var.minio_password != null && var.minio_password != "null" ? var.minio_password : random_password.minio_password.result
+  valkey_password_final  = var.valkey_password != null && var.valkey_password != "null" ? var.valkey_password : random_password.valkey_password.result
+  minio_user             = "minioadmin"
+}
+
+############################
+# Secrets
+############################
+
+resource "osc_secret" "dbpwd" {
+  service_ids  = ["birme-osc-postgresql", "postgrest-postgrest"]
+  secret_name  = "${var.solution_name}dbpwd"
+  secret_value = local.db_password_final
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "osc_secret" "couchpwd" {
+  service_ids  = ["apache-couchdb", "eyevinn-openauth-pwd"]
+  secret_name  = "${var.solution_name}couchpwd"
+  secret_value = local.couchdb_password_final
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "osc_secret" "miniopwd" {
+  service_ids  = ["minio-minio"]
+  secret_name  = "${var.solution_name}miniopwd"
+  secret_value = local.minio_password_final
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "osc_secret" "miniouser" {
+  service_ids  = ["minio-minio"]
+  secret_name  = "${var.solution_name}miniouser"
+  secret_value = local.minio_user
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "osc_secret" "valkeypwd" {
+  service_ids  = ["valkey-io-valkey"]
+  secret_name  = "${var.solution_name}valkeypwd"
+  secret_value = local.valkey_password_final
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+############################
+# Phase 1: Infrastructure Services
+############################
+
+resource "osc_birme_osc_postgresql" "this" {
+  name              = var.solution_name
+  postgres_password = format("{{secrets.%s}}", osc_secret.dbpwd.secret_name)
+  postgres_db       = "mobileapp"
+  postgres_user     = "appuser"
+}
+
+resource "osc_apache_couchdb" "this" {
+  name           = var.solution_name
+  admin_password = format("{{secrets.%s}}", osc_secret.couchpwd.secret_name)
+}
+
+resource "osc_valkey_io_valkey" "this" {
+  name     = var.solution_name
+  password = format("{{secrets.%s}}", osc_secret.valkeypwd.secret_name)
+}
+
+resource "osc_minio_minio" "this" {
+  name          = var.solution_name
+  root_user     = format("{{secrets.%s}}", osc_secret.miniouser.secret_name)
+  root_password = format("{{secrets.%s}}", osc_secret.miniopwd.secret_name)
+}
+
+resource "osc_flyimg_flyimg" "this" {
+  name = var.solution_name
+}
+
+############################
+# Phase 2: API Layer
+############################
+
+resource "osc_postgrest_postgrest" "this" {
+  name         = var.solution_name
+  db_uri       = format("postgresql://appuser:{{secrets.%s}}@%s:%d/mobileapp", osc_secret.dbpwd.secret_name, osc_birme_osc_postgresql.this.external_ip, osc_birme_osc_postgresql.this.external_port)
+  db_anon_role = "appuser"
+  db_schemas   = "public"
+  depends_on   = [osc_birme_osc_postgresql.this]
+}
+
+############################
+# Phase 3: Auth Layer
+############################
+
+resource "osc_eyevinn_openauth_pwd" "this" {
+  name            = var.solution_name
+  user_db_url     = format("http://admin:{{secrets.%s}}@%s:%d", osc_secret.couchpwd.secret_name, osc_apache_couchdb.this.external_ip, osc_apache_couchdb.this.external_port)
+  smtp_mailer_url = var.smtp_url
+  depends_on      = [osc_apache_couchdb.this]
+}
+
+############################
+# Outputs
+############################
+
+output "postgresql_url" {
+  value       = format("postgresql://appuser@%s:%d/mobileapp", osc_birme_osc_postgresql.this.external_ip, osc_birme_osc_postgresql.this.external_port)
+  description = "PostgreSQL connection URL (add password to connect)"
+}
+
+output "rest_api_url" {
+  value       = osc_postgrest_postgrest.this.instance_url
+  description = "PostgREST auto-generated REST API URL"
+}
+
+output "minio_console_url" {
+  value       = osc_minio_minio.this.instance_url
+  description = "MinIO console URL"
+}
+
+output "minio_endpoint" {
+  value       = format("%s:%d", osc_minio_minio.this.external_ip, osc_minio_minio.this.external_port)
+  description = "MinIO S3-compatible endpoint (host:port)"
+}
+
+output "minio_access_key" {
+  value       = local.minio_user
+  description = "MinIO access key (S3 access key ID)"
+}
+
+output "auth_url" {
+  value       = osc_eyevinn_openauth_pwd.this.instance_url
+  description = "OpenAuth Password service URL"
+}
+
+output "valkey_url" {
+  value       = format("redis://%s:%d", osc_valkey_io_valkey.this.external_ip, osc_valkey_io_valkey.this.external_port)
+  description = "Valkey (Redis-compatible) connection URL"
+}
+
+output "flyimg_url" {
+  value       = osc_flyimg_flyimg.this.instance_url
+  description = "Flyimg image transform service URL"
+}


### PR DESCRIPTION
Fixes Eyevinn/osaas-app#2604

Adds a one-click Mobile Backend Starter (BaaS) solution that composes 7 OSC services:

- PostgreSQL (relational database)
- PostgREST (auto-generated REST API from database schema)
- MinIO (S3-compatible object storage)
- OpenAuth Password (email/password authentication with JWT)
- Valkey (Redis-compatible cache and session store)
- Flyimg (on-demand image transforms)
- CouchDB (user store for the auth service)

Users provide their OSC PAT, a solution name, and an SMTP URL. All service passwords are auto-generated unless explicitly supplied. Services are wired together via OSC secrets with proper dependency ordering across three deploy phases (infrastructure -> API layer -> auth layer).