### PR TITLE
Add TAMS pipeline solution example

### DIFF
--- a/examples/tams-pipeline/README.md
+++ b/examples/tams-pipeline/README.md
@@ -1,0 +1,62 @@
+## Terraform/OpenTofu Example - TAMS pipeline
+
+This solution deploys a complete [TAMS](https://github.com/bbc/tams) (Time-addressable Media Store) gateway on OSC, using the following components
+
+- TAMS Gateway (the TAMS API)
+- MinIO (S3 compatible storage for media essence)
+- CouchDB (segment/flow metadata index)
+
+The bucket name is a deploy input, so MinIO and CouchDB are provisioned in parallel. The only hard ordering edge is that the bucket must exist before the gateway boots, since the gateway never creates buckets itself. `create_buckets.sh` retries to absorb MinIO startup.
+
+See general guidelines [here](../../README.md#quick-guide---general)
+
+### Solution variables
+
+- Env variables that need to be set
+
+```bash
+export TF_VAR_osc_pat = <osc personal access token>
+export TF_VAR_minio_username = <User name for the MinIO storage, min 3 chars>
+export TF_VAR_minio_password = <Password for the MinIO storage, min 10 chars, upper+lower+digit>
+export TF_VAR_couchdb_password = <Password for the CouchDB admin user>
+```
+
+Optional variables (with defaults): `tams_name` (default `tams`), `tams_bucket` (default `tams`), `osc_environment` (default `prod`). Use a dot-free bucket name.
+
+### Provider
+
+This example requires the `EyevinnOSC/osc` provider `>= 0.8.0`, which is the first release to expose the required `s3_bucket` argument on `osc_eyevinn_tams_gateway`.
+
+### AWS CLI
+
+! Note that the AWS CLI has to be installed since the terraform deployment takes care of creating the bucket automatically
+
+For installing, please see: [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
+
+Note!! - S3 CLI Env Var `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` must match `minio_username` and `minio_password`
+
+### Using
+
+1. Deploy the solution using the terraform/tofu script
+
+   ```bash
+   terraform init
+   terraform apply
+   ```
+
+   The deployment outputs the gateway, MinIO and CouchDB instance URLs.
+
+2. The gateway runs behind the OSC ingress access gate, which authenticates callers by validating a Service Access Token (SAT) before the request reaches the gateway. Obtain a SAT and call the API with it:
+
+   ```bash
+   npx @osaas/cli service-access-token eyevinn-tams-gateway
+   curl -H "Authorization: Bearer <sat>" <tams_gateway_url>/
+   ```
+
+### CouchDB backups (not in this template)
+
+`eyevinn-db-backuper` performs a single backup or restore and exits (it is a job, not a long-running service), so it is intentionally not a deploy-time resource here. Schedule recurring CouchDB backups after deploy via OSC's backup scheduler against the CouchDB instance, targeting a backups bucket.
+
+### Native AWS S3 instead of MinIO
+
+This template wires MinIO and sets `s3_endpoint_url` to the MinIO instance (path-style). The gateway also supports native AWS S3: leave `S3_ENDPOINT_URL` unset and the SDK resolves the endpoint from `AWS_REGION`. To target AWS instead of MinIO you would drop the MinIO resource, create the bucket out-of-band, and supply real IAM credentials as `aws_access_key_id` / `aws_secret_access_key`. Use a dot-free bucket name for AWS (virtual-hosted TLS).

--- a/examples/tams-pipeline/create_buckets.sh
+++ b/examples/tams-pipeline/create_buckets.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Create the S3 bucket(s) on a (possibly just-started) S3-compatible endpoint.
+# Retries to ride out MinIO startup propagation. Same pattern as the shipped OSC
+# example pipelines (EyevinnOSC/terraform-examples). Authenticates with the
+# instance's own root credentials via AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+# (set by the Terraform local-exec environment), so it never hits the
+# create-storage-bucket MCP path that fails on dedicated MinIO instances.
+#
+# Requires: aws-cli and bash on the machine running `terraform apply`.
+
+endpoint="$1"
+shift # remaining args are bucket names
+
+for bucket in "$@"; do
+  echo "Creating bucket: $bucket"
+  for i in {1..30}; do
+    result=$(aws --endpoint-url "$endpoint" s3 mb "s3://$bucket" 2>&1)
+
+    # Success if the bucket was created or already owned by us.
+    if [[ $result == *"make_bucket:"* ]] || [[ $result == *"BucketAlreadyOwnedByYou"* ]]; then
+      echo "Bucket $bucket created or already exists ($result)"
+      break
+    fi
+
+    echo "Waiting for storage... (attempt $i/30, result: $result)"
+    sleep 10
+
+    if [[ $i -eq 30 ]]; then
+      echo "Failed to create bucket $bucket after $i attempts" >&2
+      exit 1
+    fi
+  done
+done
+
+echo "All buckets are ready!"
+exit 0

--- a/examples/tams-pipeline/main.tf
+++ b/examples/tams-pipeline/main.tf
@@ -1,0 +1,163 @@
+terraform {
+  required_version = ">= 1.6.0" # Compatible with Terraform >= 1.6.0 and OpenTofu >= 1.6.0
+  required_providers {
+    osc = {
+      source  = "registry.terraform.io/EyevinnOSC/osc"
+      version = "0.8.0" # v0.8.0 adds the required s3_bucket argument to osc_eyevinn_tams_gateway. Released 2026-06-18.
+    }
+  }
+}
+
+############################
+# Variables
+############################
+variable "osc_pat" {
+  type        = string
+  sensitive   = true
+  description = "Eyevinn OSC Personal Access Token"
+}
+
+variable "osc_environment" {
+  type        = string
+  default     = "prod"
+  description = "OSC environment (prod|stage|dev)"
+}
+
+variable "tams_name" {
+  type        = string
+  default     = "tams"
+  description = "Instance name shared by the stack. Lower case letters and numbers only (OSC naming rule)."
+}
+
+variable "tams_bucket" {
+  type        = string
+  default     = "tams"
+  description = "S3 bucket for media objects. Created in MinIO by this template; the gateway never creates buckets. Use a dot-free name (native AWS S3 virtual-hosted TLS)."
+}
+
+variable "minio_username" {
+  type        = string
+  sensitive   = true
+  description = "MinIO root user. Supplied to the gateway as AWS_ACCESS_KEY_ID (MinIO speaks the S3 protocol)."
+}
+
+variable "minio_password" {
+  type        = string
+  sensitive   = true
+  description = "MinIO root password. Supplied to the gateway as AWS_SECRET_ACCESS_KEY. Min 10 chars, lower + upper + digit (minio-minio pattern)."
+}
+
+variable "couchdb_password" {
+  type        = string
+  sensitive   = true
+  description = "CouchDB admin password (the gateway's DB_PASSWORD)."
+}
+
+# No api_token variable: on OSC the ingress access gate authenticates callers via a
+# Service Access Token (SAT), so the gateway runs without its own bearer token.
+# (API_TOKEN is optional in the gateway, and ApiToken was removed from the
+# eyevinn-tams-gateway catalog schema.) For a standalone, gate-less deployment you
+# would set API_TOKEN out of band; this OSC Solution does not.
+
+############################
+# Provider
+############################
+provider "osc" {
+  pat         = var.osc_pat
+  environment = var.osc_environment
+}
+
+############################
+# Secrets (created first; referenced by {{secrets.NAME}})
+############################
+resource "osc_secret" "miniousername" {
+  service_ids  = ["minio-minio", "eyevinn-tams-gateway"]
+  secret_name  = "${var.tams_name}miniousername"
+  secret_value = var.minio_username
+}
+
+resource "osc_secret" "miniopassword" {
+  service_ids  = ["minio-minio", "eyevinn-tams-gateway"]
+  secret_name  = "${var.tams_name}miniopassword"
+  secret_value = var.minio_password
+}
+
+resource "osc_secret" "couchdbpassword" {
+  service_ids  = ["apache-couchdb", "eyevinn-tams-gateway"]
+  secret_name  = "${var.tams_name}couchdbpassword"
+  secret_value = var.couchdb_password
+}
+
+############################
+# MinIO (S3 essence store)
+############################
+resource "osc_minio_minio" "this" {
+  name          = var.tams_name
+  root_user     = format("{{secrets.%s}}", osc_secret.miniousername.secret_name)
+  root_password = format("{{secrets.%s}}", osc_secret.miniopassword.secret_name)
+}
+
+############################
+# Bucket creation: the proven null_resource + local-exec pattern.
+# The bucket name is a deploy input, so MinIO and CouchDB provision in parallel;
+# the only hard ordering edge is "bucket ready before the gateway starts". The
+# create_buckets.sh retry loop tolerates a freshly-started MinIO.
+############################
+resource "null_resource" "create_bucket" {
+  depends_on = [osc_minio_minio.this]
+
+  provisioner "local-exec" {
+    command     = "${path.module}/create_buckets.sh ${osc_minio_minio.this.instance_url} ${var.tams_bucket}"
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      AWS_ACCESS_KEY_ID     = var.minio_username
+      AWS_SECRET_ACCESS_KEY = var.minio_password
+    }
+  }
+}
+
+############################
+# CouchDB (segment/flow metadata index)
+############################
+resource "osc_apache_couchdb" "this" {
+  name           = var.tams_name
+  admin_password = format("{{secrets.%s}}", osc_secret.couchdbpassword.secret_name)
+}
+
+############################
+# TAMS gateway (boots only after the bucket exists and CouchDB is reachable)
+############################
+resource "osc_eyevinn_tams_gateway" "this" {
+  name                  = var.tams_name
+  db_url                = osc_apache_couchdb.this.instance_url
+  db_username           = "admin"
+  db_password           = format("{{secrets.%s}}", osc_secret.couchdbpassword.secret_name)
+  aws_access_key_id     = var.minio_username
+  aws_secret_access_key = format("{{secrets.%s}}", osc_secret.miniopassword.secret_name)
+  s3_endpoint_url       = osc_minio_minio.this.instance_url
+  # s3_bucket is a REQUIRED argument as of provider v0.8.0 (2026-06-18).
+  s3_bucket             = var.tams_bucket
+  # No api_token: the OSC access gate authenticates via SAT (see the variables
+  # section). ApiToken was removed from the eyevinn-tams-gateway catalog schema, so
+  # the provider resource takes no token argument here.
+
+  depends_on = [
+    null_resource.create_bucket, # bucket must pre-exist; the gateway never creates it
+    osc_apache_couchdb.this      # DB reachable for the gateway's startup auto-create
+  ]
+}
+
+############################
+# Outputs
+############################
+output "tams_gateway_url" {
+  value = osc_eyevinn_tams_gateway.this.instance_url
+}
+
+output "minio_instance_url" {
+  value = osc_minio_minio.this.instance_url
+}
+
+output "couchdb_instance_url" {
+  value = osc_apache_couchdb.this.instance_url
+}


### PR DESCRIPTION
## Summary

Adds `examples/tams-pipeline/` - a Terraform/OpenTofu example that deploys a complete TAMS (Time-addressable Media Store) gateway on OSC as a one-click stack, matching the layout of the existing pipeline examples (`README.md` + `main.tf` + `create_buckets.sh`).

Components:

| Resource | Service | Role |
|---|---|---|
| `osc_minio_minio.this` | `minio-minio` | S3-compatible object store for media essence |
| `null_resource.create_bucket` | local-exec | creates the bucket in MinIO before the gateway starts |
| `osc_apache_couchdb.this` | `apache-couchdb` | segment/flow metadata index |
| `osc_eyevinn_tams_gateway.this` | `eyevinn-tams-gateway` | the TAMS API |

## Notes for reviewers

- **Bucket pre-creation:** the TAMS gateway requires its S3 bucket to exist at startup and never creates buckets itself, so the bucket is created with the same `null_resource` + `create_buckets.sh` pattern used by `vod-pipeline` and `ad-pipeline`, authenticated with the MinIO instance's own root credentials. `depends_on` enforces the single hard edge: bucket ready before the gateway boots.
- **Provider version:** pinned to `EyevinnOSC/osc >= 0.8.0`, the first release that exposes the required `s3_bucket` argument on `osc_eyevinn_tams_gateway`. Earlier provider versions reject `s3_bucket` as an unsupported argument, so this example needs 0.8.0+.
- **Auth:** no `api_token` is set - on OSC the gateway runs behind the ingress access gate (Service Access Token), and `ApiToken` was removed from the catalog schema. The README documents how a caller obtains a SAT.
- **Backups:** `eyevinn-db-backuper` is a one-shot job, not a long-running service, so it is intentionally not a deploy-time resource; recurring backups are a post-deploy scheduling concern (noted in the README).

## Validation

`tofu init` + `tofu validate` pass against provider v0.8.0:

```
- Installed registry.terraform.io/eyevinnosc/osc v0.8.0 (signed)
Success! The configuration is valid.
```

A full `tofu apply` against live OSC instances is the recommended next gate before this is registered in the OSC solution catalog.